### PR TITLE
Update SDL_render.py

### DIFF
--- a/sdl3/SDL_render.py
+++ b/sdl3/SDL_render.py
@@ -14,7 +14,7 @@ SDL_SOFTWARE_RENDERER = "software".encode()
 class SDL_Vertex(ctypes.Structure):
     _fields_ = [
         ("position", SDL_FPoint),
-        ("color", SDL_Color),
+        ("color", SDL_FColor),
         ("tex_coord", SDL_FPoint)
     ]
 


### PR DESCRIPTION
"This fixes SDL_RenderGeometry() by changing SDL_Vertex.color from SDL_Color to SDL_FColor, which matches SDL3’s expected type."