### PR TITLE
add SDL_AppInit argument parser

### DIFF
--- a/sdl3/__init__.py
+++ b/sdl3/__init__.py
@@ -354,6 +354,9 @@ class SDL_FUNC_TYPE:
 SDL_ENUM: typing.TypeAlias = SDL_TYPE["SDL_ENUM", ctypes.c_int]
 SDL_VA_LIST: typing.TypeAlias = SDL_TYPE["SDL_VA_LIST", ctypes.c_char_p]
 
+def SDL_PARSE_ARGUMENTS(argc: ctypes.c_int, argv: SDL_POINTER[ctypes.c_char_p]) -> typing.List[str]:
+    return [SDL_DEREFERENCE(argv[i]).decode("utf-8") for i in range(argc)]
+
 def SDL_PROCESS_DESCRIPTION(description: str, url: str | None = None, rst: bool = False) -> str:
     """Process HTML description."""
 


### PR DESCRIPTION
Added function to convert the c strings passed into `SDL_AppInit` to python strings. It seems like a pretty common use case that  is worth implemented.

**minimal example:**
```python
import os, ctypes

os.environ["SDL_MAIN_USE_CALLBACKS"] = "1"

import sdl3

def SDL_AppInit(appstate: sdl3.LP_c_void_p, argc: ctypes.c_int, argv: sdl3.LP_c_char_p) -> sdl3.SDL_AppResult:
    args = sdl3.SDL_PARSE_ARGUMENTS(argc, argv)

    for i, arg in enumerate(args):
        sdl3.SDL_LOGGER.Log(sdl3.SDL_LOGGER.Info, f"Arg[{i}]: {arg}")
    
    return sdl3.SDL_APP_FAILURE

def SDL_AppEvent(appstate: ctypes.c_void_p, event: sdl3.LP_SDL_Event) -> sdl3.SDL_AppResult:
    ...

def SDL_AppIterate(appstate: ctypes.c_void_p) -> sdl3.SDL_AppResult:
    ...

def SDL_AppQuit(appstate: ctypes.c_void_p, result: sdl3.SDL_AppResult) -> None:
    ...
```